### PR TITLE
WPSpin PlayList widget warning message

### DIFF
--- a/viewmodels/playlistwidgetview.php
+++ b/viewmodels/playlistwidgetview.php
@@ -28,7 +28,7 @@ class PlaylistWidgetView extends \WP_Widget {
 
   }
 
-  public function form($new_instance, $old_instance) {
+  public function form($new_instance, $old_instance = NULL) {
 
   }
 


### PR DESCRIPTION
I'm getting a warning message when I add the WPSpin PlayList widget to a widget area. Here's the warning message text:

`Warning: Missing argument 2 for WPSpin\PlaylistWidgetView::form(), called in /path/to/wordpress/wp-includes/widgets.php on line 270 and defined in /path/to/wordpress/wp-content/plugins/WPSpin/viewmodels/playlistwidgetview.php on line 31`

![wpspin_warning](https://f.cloud.github.com/assets/1000292/277516/5336cf36-90c9-11e2-93b3-bf034be17747.PNG)

**Word of warning**: I don't fully understand how this second parameter is being used so I don't know what other ramifications this change might have. Feel free to reject if this is the wrong way to address the issue!

_Also, if you don't already have plans to do this, I was going to look into making it so the user can specify the number of plays to be displayed._
